### PR TITLE
feat: add custom output directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ Backstage is released under Mozilla Public License 2.0. See [LICENSE](./LICENSE)
 Launchcode is packaged as Docker image and can be run on any platform where DOcker is supported. To generate launchers for all platforms, run the following command:
 
 ```bash
-docker run -v ${PWD}:/workspace  ghcr.io/bitshifted/launchcode:<version> config-file.yaml
+docker run -v ${PWD}:/workspace  ghcr.io/bitshifted/launchcode:<version> config-file.yaml [output-dir]
 ```
 
 This command mounts the current directory into `/workspace` directory in container. Argument `config-file.yaml` is a configuration file for installers generation. It is assumed that configuration file is in a present directory.
+
+Argument `output-dir` is the directory where generated launchers will be placed. This argument is optional. If not specified, default directory `dist` will be used.
 
 Generated installers will be placed in `dist` directory inside the current directory. Contents of this directory will look like this:
 

--- a/docker/build-launchers.sh
+++ b/docker/build-launchers.sh
@@ -6,12 +6,17 @@ LAUNCHCODE_EMBED_DIR=$LAUNCHCODE_SRC_DIR/config/embed
 LINUX_CONFIG_DIR=${PWD}/output/linux
 MAC_CONFIG_DIR=${PWD}/output/mac
 WINDOWS_CONFIG_DIR=${PWD}/output/windows
-DIST_DIR=dist
 DEFAULT_ICON="launchcode.ico"
+ORIGIN_DIST_DIR=dist
+DIST_DIR=$2
 
 if [ -z $1 ];then
     echo "Usage: build-launchers <config-file>"
     exit 1
+fi
+
+if [ -z $DIST_DIR ];then
+    DIST_DIR="dist"
 fi
 
 echo "Using configuration file $1"
@@ -30,7 +35,7 @@ echo "Linux launcher built successfully!"
 echo "Building Mac OS launchers..."
 rm -v $LAUNCHCODE_EMBED_DIR/*
 cp $MAC_CONFIG_DIR/* $LAUNCHCODE_EMBED_DIR
-make build-mac
+make build-mac 
 echo "Mac OS launcher built sucessfully"
 
 echo "Building Windows launchers..."
@@ -52,7 +57,8 @@ make build-windows
 echo "Windows launcher built sucessfully"
 
 cd $WORKDIR
-cp -rv /usr/src/launchcode/$DIST_DIR .
+mkdir -p $DIST_DIR
+cp -rv /usr/src/launchcode/$ORIGIN_DIST_DIR/* ./$DIST_DIR
 OWNER_ID=$(stat -c %u $1)
 GROUP_ID=$(stat -c %g $1)
 chown -R $OWNER_ID:$GROUP_ID $DIST_DIR


### PR DESCRIPTION
Add support for custom output directory.
If not specified, default output directory `dist` will be used.